### PR TITLE
Fix that javascript not triggering correctly after reflex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 channels>=2.0
-inflector
 channels_redis
 bs4

--- a/sockpuppet/channel.py
+++ b/sockpuppet/channel.py
@@ -1,6 +1,6 @@
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
-from .utils import camelize
+from .utils import camelize, camelize_value
 
 
 class Channel:
@@ -39,12 +39,6 @@ class Channel:
         }
 
     def broadcast(self):
-        def camelize_value(value):
-            if isinstance(value, list):
-                for num, obj in enumerate(value):
-                    value[num] = {camelize(key): value for key, value in obj.items()}
-            return value
-
         operations = {
             camelize(key): camelize_value(value)
             for key, value in self.operations.items() if value

--- a/sockpuppet/utils.py
+++ b/sockpuppet/utils.py
@@ -1,11 +1,21 @@
-from inflector import Inflector
-
-inflector = Inflector()
+import re
 
 
 def camelize(word):
-    word = inflector.camelize(word)
-    return '{}{}'.format(word[0].lower(), word[1:])
+    word = re.sub(
+        r'[\s_](.)',
+        lambda m: m.group(1).title(),
+        word, flags=re.DOTALL
+    )
+    return word
+
+
+def camelize_value(value):
+    if isinstance(value, list):
+        value = [camelize_value(val) for val in value]
+    elif isinstance(value, dict):
+        value = {camelize(key): camelize_value(val) for key, val in value.items()}
+    return value
 
 
 def classify(word):


### PR DESCRIPTION
We were missing to add `last` when broadcasting to cable ready, an attribute that is needed later in javascript. It also didn't transform the keys entirely correctly to `camelCase`. 

Using the inflector library it'll convert `data-controller` to `dataController` something that we are not interested in. So we roll our own. 

We also make a recursive call so that an entire list or object gets all their keys transformed correctly. 