### PR TITLE
:pencil: Adds local quickstart reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ invoke release -b feature
 
 [1]: https://github.com/hopsoft/stimulus_reflex
 [2]: https://youtu.be/Z2DU0qLfPIY?t=670
-[3]: #
+[3]: ./docs/quickstart-django.md

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hit me up on twitter if you have any questions.  [![Twitter follow](https://img.
 
 ## 📚 Documentation
 
-- [Official Documentation](https://sockpuppet.argpar.se)
+- [Official Documentation](https://sockpuppet.argpar.se/docs/)
 
 ## ⚡️ Get started
 
@@ -92,4 +92,4 @@ invoke release -b feature
 
 [1]: https://github.com/hopsoft/stimulus_reflex
 [2]: https://youtu.be/Z2DU0qLfPIY?t=670
-[3]: ./docs/quickstart-django.md
+[3]: https://sockpuppet.argpar.se/docs/quickstart-django


### PR DESCRIPTION
I poked at various urls on the docs website to find this, but no luck. 