### PR TITLE
Introduce compatibility with stimulus-reflex 3.4

### DIFF
--- a/cypress/integration/websocket_spec.js
+++ b/cypress/integration/websocket_spec.js
@@ -2,7 +2,7 @@ describe("Integration tests", () => {
   it("has session persistance for anonymous user!", () => {
     cy.visit('/test/')
     cy.get('#counter').should('have.text', '0')
-    cy.wait(100)
+    cy.wait(200)
 
     cy.get('#link').click()
     cy.get('#counter').should('have.text', '1')
@@ -15,7 +15,7 @@ describe("Integration tests", () => {
   it("able to use reflex which isn't registered", () => {
     cy.visit('/test/')
     cy.get('#counter-2').should('have.text', '0')
-    cy.wait(100)
+    cy.wait(200)
 
     cy.get('#decrementor').click()
     cy.get('#counter-2').should('have.text', '-1')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sockpuppet-js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -248,12 +248,18 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
         channel = Channel(reflex.get_channel_id(), identifier=data['identifier'])
         logger.debug('Broadcasting to %s', reflex.get_channel_id())
 
+        # TODO can be removed once stimulus-reflex has increased a couple of versions
+        permanent_attribute_name = data.get('permanent_attribute_name')
+        if not permanent_attribute_name:
+            # Used in stimulus-reflex >= 3.4
+            permanent_attribute_name = data['permanentAttributeName']
+
         for selector in selectors:
             channel.morph({
                 'selector': selector,
                 'html': ''.join([e.decode_contents() for e in document.select(selector)]),
                 'children_only': True,
-                'permanent_attribute_name': data['permanent_attribute_name'],
+                'permanent_attribute_name': permanent_attribute_name,
                 'stimulus_reflex': {**data}
             })
         channel.broadcast()


### PR DESCRIPTION
The javascript for stimulus-reflex changed the parameter `permanent_attribute_name` to permanentAttributeName`. So this PR aims to fix this incompatibility. 