### PR TITLE
Always install the latest stimulus-reflex in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,10 @@ whitelist_externals =
 commands =
     sh -c "pwd"
     npm install
+    npm remove stimulus_reflex
+    npm install stimulus_reflex
+    npm install cable_ready
+    npm install @rails/actioncable
     npm run build:test
     sh -c "python manage.py migrate"
     sh -c "python manage.py runserver 2>&1 > /dev/null &"


### PR DESCRIPTION
We want to always install the latest javascript for stimulus-reflex so that we can catch any regressions and take these into account at a later stage. 