### PR TITLE
When using the channel separately to broadcast frontend should listen

### DIFF
--- a/sockpuppet/channel.py
+++ b/sockpuppet/channel.py
@@ -1,6 +1,10 @@
+import json
+import logging
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from .utils import camelize, camelize_value
+
+logger = logging.getLogger(__name__)
 
 
 class Channel:
@@ -10,6 +14,8 @@ class Channel:
     '''
 
     def __init__(self, name, identifier=''):
+        if not identifier:
+            identifier = json.dumps({'channel': name}).replace(' ', '')
         self.identifier = identifier
         self.name = name
         self.operations = self.stub()

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -190,6 +190,7 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
 
     def subscribe(self, data, **kwargs):
         name = self._get_channelname(data['channelName'])
+        logger.debug('Subscribe %s to %s', self.channel_name, name)
         async_to_sync(self.channel_layer.group_add)(
             name,
             self.channel_name

--- a/sockpuppet/reflex.py
+++ b/sockpuppet/reflex.py
@@ -31,3 +31,7 @@ class Reflex:
         request.session = self.consumer.scope['session']
         request.user = self.consumer.scope['user']
         return request
+
+    def reload(self):
+        """A default reflex to force a refresh"""
+        pass


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bugfix

## Description

The issue being that frontend identifies a json structure for the
identifier, and when stringifying a json there is no space.

In python when dumping a json there is a space. So there is a
mismatch when comparing the identifiers and so no subscription
is found.

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
