### PR TITLE
If lxml and cssselect is installed we use them for better perf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Hit me up on twitter if you have any questions.  [![Twitter follow](https://img.
 ```bash
 pip install django-sockpuppet
 
+# If performance is important you can take advantage lxml parsing
+# It will typically speed up the round trip by 30-90ms depending on the html
+pip install django-sockpuppet[lxml]
+
 # Add these into INSTALLED_APPS in settings.py
 INSTALLED_APPS = [
     'channels',

--- a/docs/setup-django.md
+++ b/docs/setup-django.md
@@ -11,6 +11,11 @@ You can easily install Sockpuppet to new and existing Django projects.
 ```bash
 pip install django-sockpuppet
 
+# If performance is important you can take advantage lxml parsing
+# It will typically speed up the round trip by 30-90ms depending on the html
+pip install django-sockpuppet[lxml]
+
+
 # Add these into INSTALLED_APPS in settings.py
 INSTALLED_APPS = [
     'channels',

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
     packages=[
         'sockpuppet',
     ],
+    extras_require={
+        "lxml": ["lxml", "cssselect"],
+    },
     include_package_data=True,
     install_requires=requirements,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
If you install sockpuppet with
```
pip install django-sockpuppet[lxml]
```

It will install everything that is required for django-sockpuppet to use the lxml parser when parsing all html fragments. This typically saves between 30-90ms depending on the complexity of the html we are parsing. 

Needs some more testing with sockpuppet expo so that we actually have the same behaviour. Saw that there was some issues with the calendar view. 

Fixes #46 

## Why should this be added
If you want a faster experience you can get one, if you're not able to install lxml (for whatever reason) you'll still be able to use beautiful soup. 

## Checklist

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
