### PR TITLE
generate package.json as part of inital_sockpuppet command

### DIFF
--- a/sockpuppet/management/commands/initial_sockpuppet.py
+++ b/sockpuppet/management/commands/initial_sockpuppet.py
@@ -10,7 +10,9 @@ class Command(BaseGenerateCommand):
     help = "Generate scaffolding to compile javascript."
 
     def handle(self, *args, **options):
+        init = 'npm init -y'
         install = 'npm install -g add-project-script'
+        subprocess.check_call(init, shell=True)
         subprocess.check_call(install, shell=True)
         try:
             build = 'add-project-script -n "build" -v "webpack --mode production"'


### PR DESCRIPTION
# Fix

## Description
package.json is not currently being generated as part of `python manage.py initial_sockpuppet`.

add npm init -y to the initialize script in order to generate package.json.

## Why should this be added
if package.json is not present at the moment that python manage.py initial_sockpuppet runs, it will generate the package-lock.json and webpack.conf.json but not the package.json for maintaining dependencies

## Checklist

- [X] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
