### PR TITLE
Fixes to SocketpuppetConsumer for handling dotfiles

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -r requirements_test.txt
+-r requirements.txt
 
 django-extensions
 invoke


### PR DESCRIPTION
    1. Update requirements_dev.txt to include base requirements, as
       these are necessary for starting the server and performing any tests.

    2. Use Reflex.__subclasses__() rather than name checking for reflex
       subclass detection, which will be more consistent and allow users
       to name their reflexes whatever they want.

    3. Clear falsey values from the filepaths detected in the
       load_reflexes_from_config function, which is a tenuous solution to
       not including vim-generated dotfiles in the module loading process.

# Type of PR (feature, enhancement, bug fix, etc.)
Bugfix and enhancement

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
