### PR TITLE
fix template syntax error

### DIFF
--- a/sockpuppet/templates/sockpuppet/scaffolds/template.html
+++ b/sockpuppet/templates/sockpuppet/scaffolds/template.html
@@ -2,7 +2,7 @@
 {% raw %}{% load static %}{% endraw %}
 <body>
     {# You'll need to make sure that the javascript is compiled and placed in the static files dirs.  #}
-    <script src="{% raw %}{% static 'js/{{ reflex_name }}.js' %}{% endraw %}"></script>
+    <script type="module" src="{% raw %}{% static 'js/{{ reflex_name }}.js' %}{% endraw %}"></script>
 
     <a  href="#"
         data-controller="{{ reflex_name }}"


### PR DESCRIPTION
#Fix

## Description
after running generate reflex.
This error shows up in the reflex code
<img width="588" alt="imagen" src="https://user-images.githubusercontent.com/19667858/103227858-2d1a4c00-490e-11eb-899c-9264ee3c934b.png">

Please include a summary of the change and which issue is fixed.
based on [this answer](https://stackoverflow.com/questions/42237388/syntaxerror-import-declarations-may-only-appear-at-top-level-of-a-module). I added the type="module" to the template.
Fixes # (issue)

## Why should this be added

Explain value.

## Checklist

- [X] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
