### PR TITLE
Bug fix: Better recovery when a Reflex isn't found.

### DIFF
--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -159,10 +159,10 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
             self.delegate_call_to_reflex(reflex, method_name, arguments)
         except Exception as e:
             error = '{}: {}'.format(e.__class__.__name__, str(e))
-            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}, {message}'.format(
+            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. A TypeError here likely indicates that the Reflex is undiscoverable. {message}'.format(
                 target=target, url=url, message=error
             )
-            self.broadcast_error(msg, data, reflex)
+            self.broadcast_error(msg, data, None)
             _, _, traceback = sys.exc_info()
             exc = SockpuppetError(msg)
             raise exc.with_traceback(traceback)

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -159,7 +159,7 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
             self.delegate_call_to_reflex(reflex, method_name, arguments)
         except Exception as e:
             error = '{}: {}'.format(e.__class__.__name__, str(e))
-            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. A TypeError here likely indicates that the Reflex is undiscoverable. {message}'.format(
+            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. A NoneType TypeError here may indicate that the Reflex is undiscoverable. {message}'.format(
                 target=target, url=url, message=error
             )
             self.broadcast_error(msg, data, None)

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -157,9 +157,14 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
             ReflexClass = self.reflexes.get(reflex_name)
             reflex = ReflexClass(self, url=url, element=element, selectors=selectors, params=params)
             self.delegate_call_to_reflex(reflex, method_name, arguments)
+        except TypeError:
+            if not self.reflexes.get(reflex_name):
+                msg = f'Sockpuppet tried to find a reflex class called {reflex_name}. Are you sure such a class exists?' # noqa
+                raise SockpuppetError(msg)
+            raise
         except Exception as e:
             error = '{}: {}'.format(e.__class__.__name__, str(e))
-            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. A NoneType TypeError here may indicate that the Reflex is undiscoverable. {message}'.format(
+            msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. {message}'.format(
                 target=target, url=url, message=error
             )
             self.broadcast_error(msg, data, None)

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -171,10 +171,10 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
             self.render_page_and_broadcast_morph(reflex, selectors, data)
         except Exception as e:
             error = '{}: {}'.format(e.__class__.__name__, str(e))
-            message = 'SockpuppetConsumer failed to re-render {url} {message}'.format(
+            msg = 'SockpuppetConsumer failed to re-render {url} {message}'.format(
                 url=url, message=error
             )
-            self.broadcast_error(message, data, reflex)
+            self.broadcast_error(msg, data, reflex)
             _, _, traceback = sys.exc_info()
             exc = SockpuppetError(msg)
             raise exc.with_traceback(traceback)


### PR DESCRIPTION
If `reflex_message()` fails to find a Reflex for whatever reason, it throws an exception. The code handling the exception expects the `reflex` variable to have been set, but in this method that variable only gets set inside the `try` block, so by definition it doesn't exist if the exception needs to be handled. `self.broadcast_error()` mandates the Reflex as a positional argument, but has conditional logic inside it that handles a case where the variable is falsey, so passing `None` in that spot solves the problem. I also added a little more detail to the text of the error message.

Fixes #52 