### PR TITLE
Proper error logging for frontend and backend

### DIFF
--- a/cypress/integration/websocket_spec.js
+++ b/cypress/integration/websocket_spec.js
@@ -47,4 +47,16 @@ describe("Integration tests", () => {
     cy.get('#decrementor').click()
     cy.get('#decrementor-counter').should('have.text', '-1')
   })
+  // TODO, use something like this https://github.com/cypress-io/cypress/issues/1922
+  // it("throws an error in frontend when using error reflex", () => {
+  //   cy.visit('/error/')
+  //   cy.wait(1000)
+
+  //   cy.get("#increment").click()
+  //   cy.window().then((win) => {
+  //     expect(win.console.log).to.have.callCount(2);
+  //     let secondCall = win.console.log.args[1][0]
+  //     expect(secondCall).to.contain('failed')
+  //   });
+  // })
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,3 +18,7 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on('window:before:load', (win) => {
+  cy.spy(win.console, 'log');
+});

--- a/sockpuppet/channel.py
+++ b/sockpuppet/channel.py
@@ -9,8 +9,12 @@ logger = logging.getLogger(__name__)
 
 class Channel:
     '''
-    Accepts a name which should either be the name of the group or the channel_name
-    to which the content will be broadcast to.
+    Accepts a name which should either be the name of the group
+    or the channel_name to which the content will be broadcast to.
+
+    Frontend makes a lookup against the identifier, if the identifier
+    exists it executes the reflex operations. If the identifier does not
+    exist, nothing will happen.
     '''
 
     def __init__(self, name, identifier=''):

--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -5,7 +5,6 @@ from importlib import import_module
 from functools import wraps
 import inspect
 from os import walk, path
-import sys
 from urllib.parse import urlparse
 from urllib.parse import parse_qsl
 
@@ -193,20 +192,23 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
             ReflexClass = self.reflexes.get(reflex_name)
             reflex = ReflexClass(self, url=url, element=element, selectors=selectors, params=params)
             self.delegate_call_to_reflex(reflex, method_name, arguments)
-        except TypeError:
+        except TypeError as exc:
             if not self.reflexes.get(reflex_name):
                 msg = f'Sockpuppet tried to find a reflex class called {reflex_name}. Are you sure such a class exists?' # noqa
-                raise SockpuppetError(msg)
-            raise
+                self.broadcast_error(msg, data)
+            else:
+                msg = str(exc)
+                self.broadcast_error(msg, data)
+            logging.exception(msg)
+            return
         except Exception as e:
             error = '{}: {}'.format(e.__class__.__name__, str(e))
             msg = 'SockpuppetConsumer failed to invoke {target}, with url {url}. {message}'.format(
                 target=target, url=url, message=error
             )
             self.broadcast_error(msg, data, None)
-            _, _, traceback = sys.exc_info()
-            exc = SockpuppetError(msg)
-            raise exc.with_traceback(traceback)
+            logging.exception(msg)
+            return
 
         try:
             self.render_page_and_broadcast_morph(reflex, selectors, data)
@@ -216,9 +218,8 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
                 url=url, message=error
             )
             self.broadcast_error(msg, data, reflex)
-            _, _, traceback = sys.exc_info()
-            exc = SockpuppetError(msg)
-            raise exc.with_traceback(traceback)
+            logging.exception(msg)
+            return
 
         logger.debug('Reflex took %6.2fms', (time.perf_counter() - start) * 1000)
 
@@ -281,13 +282,18 @@ class SockpuppetConsumer(JsonWebsocketConsumer):
         else:
             getattr(reflex, method_name)(*arguments)
 
-    def broadcast_error(self, message, data, reflex):
+    def broadcast_error(self, message, data, reflex=None):
         # We may have a sitation where we weren't able to get a reflex
         session_key = reflex.get_channel_id() if reflex else self.scope['session'].session_key
-        channel = Channel(session_key)
-        data.update({'error': 'message'})
+        channel = Channel(session_key, identifier=data['identifier'])
+        data.update({
+            'serverMessage': {
+                'subject': 'error',
+                'body': message,
+            }
+        })
         channel.dispatch_event({
-            'name': 'stimulus-reflex:500',
+            'name': 'stimulus-reflex:server-message',
             'detail': {'stimulus_reflex': data}
         })
         channel.broadcast()

--- a/sockpuppet/templates/sockpuppet/scaffolds/template.html
+++ b/sockpuppet/templates/sockpuppet/scaffolds/template.html
@@ -15,7 +15,7 @@
     {% raw %}<script src="{% static 'sockpuppet/sockpuppet.js' %}"></script>{% endraw %}
     <a
       href="#"
-      data-reflex="click->{{ reflex_name }}#increment"
+      data-reflex="click->{{ reflex_name|title}}Reflex#increment"
       data-count="{% raw %}{{ count }}{% endraw %}"
     >Increment </a><span>{% raw %}{{ count }}{% endraw %}</span>
     {% endif %}

--- a/tests/example/javascript/example.js
+++ b/tests/example/javascript/example.js
@@ -7,7 +7,7 @@ import ExampleController from './controllers/example_controller'
 
 const application = Application.start()
 const consumer = new WebsocketConsumer(
-  `ws://${window.location.host}/ws/sockpuppet-sync`, {debug: true}
+  `ws://${window.location.host}/ws/sockpuppet-sync`, {debug: false}
 )
 
 consumer.subscriptions.create('progress', {
@@ -16,4 +16,4 @@ consumer.subscriptions.create('progress', {
   }
 })
 application.register("example", ExampleController)
-StimulusReflex.initialize(application, { consumer })
+StimulusReflex.initialize(application, { consumer, debug: true})

--- a/tests/example/reflexes/example_reflex.py
+++ b/tests/example/reflexes/example_reflex.py
@@ -19,3 +19,8 @@ class ParamReflex(Reflex):
 class FormReflex(Reflex):
     def submit(self):
         self.text_output = self.request.POST['text-input']
+
+
+class ErrorReflex(Reflex):
+    def increment(self, step=1):
+        raise Exception('error happened')

--- a/tests/example/templates/error.html
+++ b/tests/example/templates/error.html
@@ -1,0 +1,14 @@
+
+{% load static %}
+<body>
+
+
+    <script src="{% static 'js/example.js' %}"></script>
+    <a
+      id="increment"
+      href="#"
+      data-reflex="click->ErrorReflex#increment"
+      data-count="{{ count }}"
+    >Increment </a><span>{{ count }}</span>
+
+</body>

--- a/tests/example/templates/param.html
+++ b/tests/example/templates/param.html
@@ -5,10 +5,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="{% static 'js/example.js' %}"></script>
   <title>Param view</title>
 </head>
 <body>
+  <script src="{% static 'js/example.js' %}"></script>
   Hello <span id="word">{{ word }}</span>
   <button id="button" data-reflex="click->ParamReflex#change_word">Change me</button>
 </body>

--- a/tests/example/urls.py
+++ b/tests/example/urls.py
@@ -16,11 +16,12 @@ Including another URLconf
 
 from django.urls import path
 
-from .views.example import ExampleView, ParamView, ProgressView, StaticView
+from .views import example
 
 urlpatterns = [
-    path('test/', ExampleView.as_view(), name='example'),
-    path('param/', ParamView.as_view(), name='param'),
-    path('test-static/', StaticView.as_view(), name='static'),
-    path('progress/', ProgressView.as_view(), name='progress')
+    path('test/', example.ExampleView.as_view(), name='example'),
+    path('param/', example.ParamView.as_view(), name='param'),
+    path('test-static/', example.StaticView.as_view(), name='static'),
+    path('progress/', example.ProgressView.as_view(), name='progress'),
+    path('error/', example.ErrorView.as_view(), name='error'),
 ]

--- a/tests/example/views/example.py
+++ b/tests/example/views/example.py
@@ -31,3 +31,12 @@ class StaticView(TemplateView):
 
 class ProgressView(TemplateView):
     template_name = 'progressbar.html'
+
+
+class ErrorView(TemplateView):
+    template_name = 'error.html'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['count'] = 0
+        return context


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bugfix

## Description
This amends the error logging on both frontend end backend. Frontend needed a slightly different structure for the error logging to work. 

For backend we don't raise an error, because when we do it disconnects the server, so it's better to catch the error and log it as an exception. That way we don't have any issues of sending the error message to frontend which we had prior to this. 

Semi-related to #3 

## Why should this be added
Gives clearer error messaging for both frontend and backend. 

## Checklist

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
