### PR TITLE
Out of band example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sockpuppet-js",
-  "version": "0.3.8",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2120,6 +2120,15 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
+    },
+    "cable_ready": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/cable_ready/-/cable_ready-4.4.6.tgz",
+      "integrity": "sha512-nqo50yrnOlV0CKc+ysXnIzwulk7q54hGYUwbJb1s0pBY0eu1yjDhgdU8g9dxfO5xapK6S7oceuEnZ4FQawbU5g==",
+      "dev": true,
+      "requires": {
+        "morphdom": "^2.6.1"
+      }
     },
     "cacache": {
       "version": "12.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "stimulus_reflex": ">=3.4.0",
         "webpack": "^4.43.0",
         "webpack-bundle-analyzer": "^3.7.0",
-        "webpack-cli": "^3.3.11"
+        "webpack-cli": "^3.3.11",
+        "cable_ready": ">= 4.4"
     },
     "dependencies": {
         "reconnecting-websocket": "^4.4.0"

--- a/tests/example/javascript/example.js
+++ b/tests/example/javascript/example.js
@@ -1,5 +1,6 @@
 import { Application } from 'stimulus'
 import StimulusReflex from 'stimulus_reflex'
+import CableReady from 'cable_ready'
 // because travis had issues with 'sockpuppet-js' we had to do this.
 import WebsocketConsumer from '../../../javascript/stimulus-websocket/index'
 import ExampleController from './controllers/example_controller'
@@ -9,5 +10,10 @@ const consumer = new WebsocketConsumer(
   `ws://${window.location.host}/ws/sockpuppet-sync`, {debug: true}
 )
 
+consumer.subscriptions.create('progress', {
+  received (data) {
+    if (data.cableReady) CableReady.perform(data.operations)
+  }
+})
 application.register("example", ExampleController)
 StimulusReflex.initialize(application, { consumer })

--- a/tests/example/management/commands/progressbar.py
+++ b/tests/example/management/commands/progressbar.py
@@ -8,14 +8,15 @@ class Command(BaseCommand):
     help = "Update the progressbar."
 
     def handle(self, *args, **options):
-        cable_ready = Channel('TestConsumer')
+        channel = Channel('progress')
         status = 0
         while status < 100:
             status += 10
-            cable_ready.set_attribute({
+            print(f'Status: {status}')
+            channel.set_attribute({
                 'selector': "#progress-bar>div",
                 'name': "style",
                 'value': "width:{status}%".format(status=status)
             })
-            cable_ready.broadcast()
+            channel.broadcast()
             time.sleep(1)  # fake some latency

--- a/tests/example/templates/progressbar.html
+++ b/tests/example/templates/progressbar.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta name="action-cable-url" content="/cable">
-    <script src="{% static 'js/cable_ready.js' %}"></script>
+    <script src="{% static 'js/example.js' %}"></script>
     <title>Hello world</title>
     <style>
          #progress-bar {
@@ -24,19 +24,6 @@
     </style>
 </head>
 <body>
-    <script>
-        let chatSocket = new WebSocket(
-            'ws://localhost:8000/ws/cable/'
-        )
-
-        chatSocket.onmessage = function(e) {
-            let data = JSON.parse(e.data);
-            console.log(data)
-            if (data.cableReady) {
-                CableReady.perform(data.operations)
-            }
-        }
-    </script>
     <h1>Progress Bar Demo</h1>
     <div id="progress-bar">
       <div></div>

--- a/tests/example/urls.py
+++ b/tests/example/urls.py
@@ -16,10 +16,11 @@ Including another URLconf
 
 from django.urls import path
 
-from .views.example import ExampleView, ParamView, StaticView
+from .views.example import ExampleView, ParamView, ProgressView, StaticView
 
 urlpatterns = [
     path('test/', ExampleView.as_view(), name='example'),
     path('param/', ParamView.as_view(), name='param'),
-    path('test-static/', StaticView.as_view(), name='static')
+    path('test-static/', StaticView.as_view(), name='static'),
+    path('progress/', ProgressView.as_view(), name='progress')
 ]

--- a/tests/example/views/example.py
+++ b/tests/example/views/example.py
@@ -27,3 +27,7 @@ class StaticView(TemplateView):
         context = super().get_context_data(*args, **kwargs)
         context['otherCount'] = self.request.session.get('otherCount', 0)
         return context
+
+
+class ProgressView(TemplateView):
+    template_name = 'progressbar.html'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -65,6 +65,15 @@ CHANNEL_LAYERS = {
     }
 }
 
+# CHANNEL_LAYERS = {
+#     "default": {
+#         "BACKEND": "channels_redis.core.RedisChannelLayer",
+#         "CONFIG": {
+#             "hosts": [("127.0.0.1", 6379)],
+#         },
+#     },
+# }
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
enhancement

## Description
This adds an out of band example of how to use django-sockpuppet. It's worth noting that the redis channel layer is a requirement for this to work (besides, redis should always be used in a production environment). 

To test this out
- Fork the library
- Install all requirements_dev.txt
- run `python manage.py runserver`
- run `npm run build:watch`
- go to http://localhost:8000/progress
- run `python manage.py progressbar`
- behold the progressbar being filled each second. 

Related to #77 

## Why should this be added
I was asked for an example :)

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
