### PR TITLE
Ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ jsdist/
 cypress/videos/
 cypress/screenshots/
 slides
+
+# VS Code
+.vscode/


### PR DESCRIPTION
`.gitignore` probably needs an editing pass so that it ignores all dotfiles, but until that happens here's a line to block the `.vscode/` folder, which a few of us have.