### PR TITLE
Spread operators necessary on variables passed to the view function.

### DIFF
--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -249,7 +249,7 @@ class BaseConsumer(JsonWebsocketConsumer):
             view.view_class.get_context_data, reflex_context
         )
 
-        response = view(reflex.request, resolved.args, resolved.kwargs)
+        response = view(reflex.request, *resolved.args, **resolved.kwargs)
         # we've got the response, the function needs to work as normal again
         view.view_class.get_context_data = original_context_data
         reflex.session.save()


### PR DESCRIPTION
This is actually a pretty substantial bug that I only now encountered when trying to reload a `DetailView`. I couldn't figure out why it wasn't able to read the URLconf until I walked through the code and discovered that the problem was immediately fixed when I applied the spread operators in the `view()` invocation.