### PR TITLE
object_list now works for ListView and similar views

### DIFF
--- a/cypress/integration/websocket_spec.js
+++ b/cypress/integration/websocket_spec.js
@@ -1,4 +1,6 @@
 describe("Integration tests", () => {
+  // TODO, use something like this https://github.com/cypress-io/cypress/issues/1922
+  // Then we can replace the cy.wait(200)
   it("has session persistance for anonymous user!", () => {
     cy.visit('/test/')
     cy.get('#counter').should('have.text', '0')
@@ -47,16 +49,24 @@ describe("Integration tests", () => {
     cy.get('#decrementor').click()
     cy.get('#decrementor-counter').should('have.text', '-1')
   })
-  // TODO, use something like this https://github.com/cypress-io/cypress/issues/1922
-  // it("throws an error in frontend when using error reflex", () => {
-  //   cy.visit('/error/')
-  //   cy.wait(1000)
 
-  //   cy.get("#increment").click()
-  //   cy.window().then((win) => {
-  //     expect(win.console.log).to.have.callCount(2);
-  //     let secondCall = win.console.log.args[1][0]
-  //     expect(secondCall).to.contain('failed')
-  //   });
-  // })
+  it("throws an error in frontend when using error reflex", () => {
+    cy.visit('/error/')
+    cy.wait(200)
+
+    cy.get("#increment").click()
+    cy.window().then((win) => {
+      expect(win.console.log).to.have.callCount(2);
+      let secondCall = win.console.log.args[1][0]
+      expect(secondCall).to.contain('failed')
+    });
+  })
+
+  it("able to use a list view without errors", () => {
+    cy.visit('/users/')
+    cy.wait(200)
+    cy.get('#button').click()
+
+    cy.get('#success').should('have.text', 'True')
+  })
 })

--- a/sockpuppet/reflex.py
+++ b/sockpuppet/reflex.py
@@ -34,8 +34,12 @@ class Reflex:
         resolved = resolve(parsed_url.path)
         view = resolved.func.view_class()
         view.request = self.request
+        try:
+            context = view.get_context_data()
+        except AttributeError:
+            view.get(self.request)
+            context = view.get_context_data()
 
-        context = view.get_context_data()
         self.context = context
         self.context.update(**kwargs)
         return self.context

--- a/tests/example/reflexes/example_reflex.py
+++ b/tests/example/reflexes/example_reflex.py
@@ -14,6 +14,7 @@ class DecrementReflex(Reflex):
 class ParamReflex(Reflex):
     def change_word(self):
         self.word = 'space'
+        self.success = True
 
 
 class FormReflex(Reflex):

--- a/tests/example/templates/param.html
+++ b/tests/example/templates/param.html
@@ -11,5 +11,6 @@
   <script src="{% static 'js/example.js' %}"></script>
   Hello <span id="word">{{ word }}</span>
   <button id="button" data-reflex="click->ParamReflex#change_word">Change me</button>
+  <div id="success">{{ success }}</div>
 </body>
 </html>

--- a/tests/example/urls.py
+++ b/tests/example/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path('test-static/', example.StaticView.as_view(), name='static'),
     path('progress/', example.ProgressView.as_view(), name='progress'),
     path('error/', example.ErrorView.as_view(), name='error'),
+    path('users/', example.UserList.as_view(), name='user'),
 ]

--- a/tests/example/views/example.py
+++ b/tests/example/views/example.py
@@ -1,4 +1,8 @@
 from django.views.generic.base import TemplateView
+from django.views.generic.list import ListView
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
 
 
 class ExampleView(TemplateView):
@@ -39,4 +43,14 @@ class ErrorView(TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['count'] = 0
+        return context
+
+
+class UserList(ListView):
+    model = User
+    template_name = 'param.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        print(self.object_list)
         return context


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description
Some views may have a 'setup' in the get part of
the view. For instance ListView expects that object_list
is added to self during the get request.

So if we get an AttributeError during the reflex we
execute the actual get request there, and then go on
to generate the context view.

## Why should this be added
It's a bug. 

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
