### PR TITLE
force npm install add-project-script

### DIFF
--- a/sockpuppet/management/commands/initial_sockpuppet.py
+++ b/sockpuppet/management/commands/initial_sockpuppet.py
@@ -11,7 +11,7 @@ class Command(BaseGenerateCommand):
 
     def handle(self, *args, **options):
         init = 'npm init -y'
-        install = 'npm install -g add-project-script'
+        install = 'npm install -g --force add-project-script'
         subprocess.check_call(init, shell=True)
         subprocess.check_call(install, shell=True)
         try:


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

overwrite existing files/links when re-installing an existing add-project-script library globally

Fixes #80 

## Why should this be added

the management command `initial_sockpuppet` fails when add-project-script is already installed.

## Checklist

- [x] Tests are passing
- [ ] Documentation has been added or amended for this feature / update (not necessary?)
