### PR TITLE
Refactored reflex.py

### DIFF
--- a/sockpuppet/reflex.py
+++ b/sockpuppet/reflex.py
@@ -36,10 +36,11 @@ class Reflex:
         view.request = self.request
         try:
             view.kwargs = resolved.kwargs
-            context = view.get_context_data()
-        except AttributeError:
             view.get(self.request)
-            context = view.get_context_data()
+        except AttributeError:
+            pass
+
+        context = view.get_context_data()
 
         self.context = context
         self.context.update(**kwargs)


### PR DESCRIPTION
view.kwargs was called in the wrong place.
It works right now because it's being rescued by the except.
Might lead to future bugs, so I thought it should be refactored. 

# Type of PR (feature, enhancement, bug fix, etc.)
 
Refactoring

## Description

Refactoring of a small part of reflex.py

## Why should this be added

My pull request #95 is working because of an except, which is not what I had in mind,
and I feel like could lead to future bugs. 

I think that doing the class based view stuff and then having an except for none class based ones looks good, but I'm not sure about performance.

## Checklist

- [x] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
