### PR TITLE
Make reflex rendering thread safe

### DIFF
--- a/sockpuppet/__init__.py
+++ b/sockpuppet/__init__.py
@@ -7,3 +7,4 @@ else:
     from sockpuppet.consumer import SockpuppetConsumer # noqa
 
 __version__ = '0.5.2'
+default_app_config = 'sockpuppet.apps.SockpuppetConfig'

--- a/sockpuppet/apps.py
+++ b/sockpuppet/apps.py
@@ -1,6 +1,60 @@
 # -*- coding: utf-8
+import inspect
+
 from django.apps import AppConfig
+from django.urls import URLPattern, URLResolver, get_resolver
+
+from .reflex import PROTECTED_VARIABLES, Reflex
 
 
 class SockpuppetConfig(AppConfig):
     name = 'sockpuppet'
+
+    def ready(self):
+        process_resolver(get_resolver())
+
+
+def get_context_data(self, **context):
+    context = self._patched_get_context_data(**context)
+
+    try:
+        reflex = self.request.reflex
+    except AttributeError:
+        pass
+    else:
+        instance_variables = [
+            name for (name, member) in inspect.getmembers(reflex)
+            if not name.startswith('__') and name not in PROTECTED_VARIABLES
+        ]
+        reflex_context = {key: getattr(reflex, key) for key in instance_variables}
+        reflex_context['stimulus_reflex'] = True
+
+        reflex.get_context_data(**reflex_context)
+        context.update(reflex_context)
+
+    return context
+
+
+def process_callback(callback):
+    try:
+        view_class = callback.view_class
+        view_class._patched_get_context_data = view_class.get_context_data
+        view_class.get_context_data = get_context_data
+    except AttributeError:
+        pass
+
+    return callback
+
+
+def process_resolver(resolver: URLResolver) -> None:
+    if resolver.callback:
+        resolver.callback = process_callback(resolver.callback)
+
+    for pattern in resolver.url_patterns:
+        if isinstance(pattern, URLPattern) and pattern.callback:
+            pattern.callback = process_callback(pattern.callback)
+        elif isinstance(pattern, URLResolver):
+            process_resolver(pattern)
+
+    if resolver._populated:
+        resolver._populate()


### PR DESCRIPTION
The monkey patch used to render the original view's context was not
thread safe. This commit fixes the issue by patching all the
get_context_data methods before accepting requests, instead of while
rendering the reflex' response.

# Type of PR (feature, enhancement, bug fix, etc.)

## Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added

Explain value.

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
