### PR TITLE
Fix the omission of the stimulus_reflex variable

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -87,7 +87,7 @@ When Sockpuppet calls your Django view, it passes any active instance variables 
 ```python
 def get_context_data(self, *args, **kwargs):
     context = super().get_context_data(*args, **kwargs)
-    if not context['stimulus_reflex']:
+    if not context.get('stimulus_reflex'):
         self.request.session['balls_left'] = 3
     return context
 ```
@@ -95,6 +95,8 @@ def get_context_data(self, *args, **kwargs):
 {% endtabs %}
 
 In this example, the user is given three new balls every time they refresh the page in their browser, effectively restarting the game. If the page state is updated via the Sockpuppet Reflex, no new balls are allocated.
+
+Since the `stimulus_reflex` variable is only available during the reflex phase and _not_ when executing the view normally you'll have to use `context.get`, otherwise you'll get an error.
 
 This also means that `self.request.session['balls_left']` will be set to 3 before the initial HTML page has been rendered and transmitted.
 

--- a/sockpuppet/reflex.py
+++ b/sockpuppet/reflex.py
@@ -36,10 +36,10 @@ class Reflex:
         view.request = self.request
         try:
             view.kwargs = resolved.kwargs
-            context = view.get_context_data()
+            context = view.get_context_data(**{'stimulus_reflex': True})
         except AttributeError:
             view.get(self.request)
-            context = view.get_context_data()
+            context = view.get_context_data(**{'stimulus_reflex': True})
 
         self.context = context
         self.context.update(**kwargs)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description
When adding `get_context_data` to the reflex class I forgot about stimulus_reflex, so it broke there. This PR fixes that.  

Fixes # (issue)
Fixes #107 

Explain value.

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
