### PR TITLE
extract/const isProd

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,9 +26,10 @@ let sourceMap = new webpack.SourceMapDevToolPlugin({
   filename: '[name].js.map'
 });
 
+const isProd = process.env.NODE_ENV === 'production'
+
 module.exports = [
   function(env, argv) {
-    isProd = process.env.NODE_ENV === 'production'
     let config = {
       mode: process.env.NODE_ENV,
       entry: entryObj,
@@ -48,7 +49,6 @@ module.exports = [
     return config
   },
   function(env, argv) {
-    isProd = process.env.NODE_ENV === 'production'
     let config = {
       mode: process.env.NODE_ENV,
       entry: sockpuppet,


### PR DESCRIPTION
# Type of PR (enhancement)

## Description
just to satisfy ESLint, as isProd is used twice and has no let/const keyword.

## Why should this be added
Just to simplify code, and make ESLint happy.
