### PR TITLE
simplify example code

### DIFF
--- a/docs/quickstart-django.md
+++ b/docs/quickstart-django.md
@@ -99,9 +99,9 @@ import StimulusReflex from 'stimulus_reflex'
 import WebsocketConsumer from 'sockpuppet-js'
 
 const application = Application.start()
-const consumer = new WebsocketConsumer('ws://localhost:8000/ws/sockpuppet-sync')
+application.consumer = new WebsocketConsumer('ws://localhost:8000/ws/sockpuppet-sync')
 
-StimulusReflex.initialize(application, { consumer })
+StimulusReflex.initialize(application)
 ```
 {% endcode %}
 
@@ -184,10 +184,10 @@ import WebsocketConsumer from 'sockpuppet-js'
 import CounterController from './controller/counter_controller.js'
 
 const application = Application.start()
-const consumer = new WebsocketConsumer('ws://localhost:8000/ws/sockpuppet-sync')
+application.consumer = new WebsocketConsumer('ws://localhost:8000/ws/sockpuppet-sync')
 
 application.register('counter', CounterController)
-StimulusReflex.initialize(application, { consumer })
+StimulusReflex.initialize(application)
 ```
 {% endcode %}
 

--- a/docs/quickstart-django.md
+++ b/docs/quickstart-django.md
@@ -69,7 +69,7 @@ We use data attributes to declaratively tell Sockpuppet to pay special attention
 
 We are also assuming that we have a view that renders this template. The view looks like this.
 
-{% code title="your\_app/view.py" %}
+{% code title="your\_app/views.py" %}
 ```python
 from django.views.generic.base import TemplateView
 

--- a/docs/setup-django.md
+++ b/docs/setup-django.md
@@ -145,10 +145,8 @@ The configuration above will look for JavaScript files in the folder `your_app/j
 If you add that folder to `STATICFILES_DIRS` in settings it will pick that compiled JavaScript and you can use it in templates.
 
 ```python
-from pathlib import Path
-BASE_DIR = Path.cwd()
 STATICFILES_DIRS = [
-    ("js", f"{BASE_DIR}/dist/js"),
+    ("js", BASE_DIR / "dist" / "js"),
 ]
 ```
 


### PR DESCRIPTION
Python since v3.4 uses pathlib for paths preferrably:  https://www.python.org/dev/peps/pep-0428/. Django, when using a new project, automatically imports `Path` in the settings:
```python
# Build paths inside the project like this: BASE_DIR / 'subdir'.
BASE_DIR = Path(__file__).resolve().parent.parent
```
no need for that. And, BASE_DIR is declared automatically too, even if is no Python standard.

- [X] Tests are passing
- [X] Documentation not needed here.
