### PR TITLE
Don't call get_context_data more than necessary

### DIFF
--- a/sockpuppet/reflex.py
+++ b/sockpuppet/reflex.py
@@ -34,12 +34,16 @@ class Reflex:
         resolved = resolve(parsed_url.path)
         view = resolved.func.view_class()
         view.request = self.request
-        try:
-            view.kwargs = resolved.kwargs
-            context = view.get_context_data(**{"stimulus_reflex": True})
-        except AttributeError:
-            view.get(self.request)
-            context = view.get_context_data(**{"stimulus_reflex": True})
+        view.kwargs = resolved.kwargs
+
+        # correct for detail and list views for django generic views
+        if hasattr(view, "get_object"):
+            view.object = view.get_object()
+
+        if hasattr(view, "paginate_queryset"):
+            view.object_list = view.get_queryset()
+
+        context = view.get_context_data(**{"stimulus_reflex": True})
 
         self.context = context
         self.context.update(**kwargs)


### PR DESCRIPTION
## Description
Figuring out which view it is and adding the correct property to
that view is better than trying to re-render the view itself.

This should solve for django's generic views. It won't work
for Django vanilla views package, but we can deal with this
later if someone show interest for that.

## Why should this be added
It removes the rendering of the view once, so it will be marginally faster. It also makes it 
easier to reason about what is happening. 

## Checklist

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
