### PR TITLE
CI for django 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.9]
-        django: ["2.2", "3.1"]
+        django: ["2.2", "3.2"]
 
     steps:
     - uses: actions/checkout@v2
@@ -83,6 +83,6 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run integration tests
         env:
-          TOX_ENV: py3.9-django3.1-channels${{ matrix.channels }}-cypress
+          TOX_ENV: py3.9-django3.2-channels${{ matrix.channels }}-cypress
         run: |
           tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-venv
 envlist =
-    {py3.6,py3.7,py3.8,py3.9}-django{2.2,3.0,3.1}
+    {py3.6,py3.7,py3.8,py3.9}-django{2.2,3.0,3.2}
 
 [testenv]
 setenv =
@@ -17,7 +17,7 @@ commands =
 deps =
     django2.2: Django>=2.2,<3.0
     django3.0: Django>=3.0,<3.1
-    django3.1: Django>=3.1,<3.2
+    django3.2: Django>=3.2,<3.3
     -r{toxinidir}/requirements_test.txt
 basepython =
     py3.9: python3.9
@@ -25,7 +25,7 @@ basepython =
     py3.7: python3.7
     py3.6: python3.6
 
-[testenv:py3.9-django3.1-channels2.4-cypress]
+[testenv:py3.9-django3.2-channels2.4-cypress]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/sockpuppet
 whitelist_externals =
@@ -42,14 +42,14 @@ commands =
     codecov -e TOXENV
 
 deps =
-    django3.1: Django>=3.1,<3.2
+    django3.1: Django>=3.2,<3.3
     channels2.4: channels<3.0
     -r{toxinidir}/requirements_test.txt
 
 basepython =
     py3.9: python3.9
 
-[testenv:py3.9-django3.1-channels3.0-cypress]
+[testenv:py3.9-django3.2-channels3.0-cypress]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/sockpuppet
 whitelist_externals =
@@ -66,7 +66,7 @@ commands =
     codecov -e TOXENV
 
 deps =
-    django3.1: Django>=3.1,<3.2
+    django3.1: Django>=3.2,<3.3
     channels3.0: channels>=3.0,<3.1
     -r{toxinidir}/requirements_test.txt
 


### PR DESCRIPTION
## Description
Adds CI for django 3.2

## Why should this be added
So that we know for sure that everything works in the most recent release of django. 

## Checklist

- [ ] Tests are passing
- [ ] Documentation has been added or amended for this feature / update
