### PR TITLE
Remove Channels 2.4 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channels: ["2.4", "3.0"]
+        channels: ["3.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -25,30 +25,6 @@ basepython =
     py3.7: python3.7
     py3.6: python3.6
 
-[testenv:py3.9-django3.2-channels2.4-cypress]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/sockpuppet
-whitelist_externals =
-    sh
-    npm
-    inv
-commands =
-    sh -c "pwd"
-    inv integration
-    sh -c "coverage run manage.py testserver cypress/fixtures/user.json --noinput &"
-    npm run cypress:run
-    sh -c "echo $(ps | grep coverage | grep -v grep | awk '\{print $1\}')"
-    sh -c "kill -s HUP $(ps | grep coverage | grep -v grep | awk '\{print $1\}')"
-    codecov -e TOXENV
-
-deps =
-    django3.1: Django>=3.2,<3.3
-    channels2.4: channels<3.0
-    -r{toxinidir}/requirements_test.txt
-
-basepython =
-    py3.9: python3.9
-
 [testenv:py3.9-django3.2-channels3.0-cypress]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/sockpuppet
@@ -66,7 +42,7 @@ commands =
     codecov -e TOXENV
 
 deps =
-    django3.1: Django>=3.2,<3.3
+    django3.2: Django>=3.2,<3.3
     channels3.0: channels>=3.0,<3.1
     -r{toxinidir}/requirements_test.txt
 


### PR DESCRIPTION
Channels 2.4 is proving problematic in CI, and it's not worth
the effort to maintain that. Sockpuppet should still work for
channels 2.4, but given we don't run a CI for it we can't make
any promises for it.

## Checklist

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
