### PR TITLE
Emit browser console error when a reflex can't be loaded

### DIFF
--- a/sockpuppet/consumer.py
+++ b/sockpuppet/consumer.py
@@ -177,8 +177,13 @@ class BaseConsumer(JsonWebsocketConsumer):
         arguments = data["args"] if data.get("args") else []
         params = dict(parse_qsl(data["formData"]))
         element = Element(data["attrs"])
-        if not self.reflexes:
-            self.load_reflexes()
+        try:
+            if not self.reflexes:
+                self.load_reflexes()
+        except Exception as e:
+            msg = f"Reflex couldn't be loaded: {str(e)}"
+            self.broadcast_error(msg, data)
+            return
 
         try:
             ReflexClass = self.reflexes.get(reflex_class_name)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description
For any usage < 3.8 it won't emit a browser error due the [following bug in python](https://bugs.python.org/issue17396), however for python >= 3.8 it will emit an console log error in the browser stating `Reflex couldn't be loaded: (start of python error here).`

Perhaps you can give this a try @nerdoc if you've got the chance? You could install it through the following command. 

```
pip install https://github.com/jonathan-s/django-sockpuppet/archive/reflex-load-error.zip
```

Fixes #137 

## Why should this be added
Clearer errors are better.  

## Checklist

- [x] Tests are passing
- [x] Documentation has been added or amended for this feature / update
